### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,15 +7,15 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-LcdHelper KEYWORD1
+LcdHelper	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-print KEYWORD2
-update KEYWORD2
-clear KEYWORD2
+print	KEYWORD2
+update	KEYWORD2
+clear	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords